### PR TITLE
FoundryVTT V14 compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -3,9 +3,9 @@
   "title": "XCrawl Classics System",
   "version": "0.4.1.4",
   "compatibility": {
-    "minimum": "13",
-    "maximum": "13",
-    "verified": "13"
+    "minimum": "14",
+    "maximum": "14",
+    "verified": "14"
   },
   "description": "<p>Adds XCrawl Classics support to the Dungeon Crawl Classics system</p>",
   "authors": [

--- a/module/xcc-actor-sheet-athlete.js
+++ b/module/xcc-actor-sheet-athlete.js
@@ -228,7 +228,7 @@ class XCCActorSheetAthlete extends XCCActorSheet {
     })
 
     const automateDamageFumblesCrits = game.settings.get('dcc', 'automateDamageFumblesCrits')
-    const rollMode = game.settings.get('core', 'rollMode')
+    const rollMode = game.settings.get('core', 'messageMode')
 
     // Accumulate all rolls for sending to the chat message
     const rolls = []
@@ -463,7 +463,7 @@ class XCCActorSheetAthlete extends XCCActorSheet {
 
     messageData.content = await foundry.applications.handlebars.renderTemplate('systems/dcc/templates/chat-card-attack-result.html', { message: messageData })
     // Output the results
-    ChatMessage.applyRollMode(messageData, rollMode)
+    ChatMessage.applyMode(messageData, rollMode)
     ChatMessage.create(messageData)
   }
 

--- a/module/xcc-actor-sheet-brawler.js
+++ b/module/xcc-actor-sheet-brawler.js
@@ -117,7 +117,7 @@ class XCCActorSheetBrawler extends XCCActorSheet {
     const type = XCCActorSheet.findDataset(target, 'itemId')
 
     const automateDamageFumblesCrits = game.settings.get('dcc', 'automateDamageFumblesCrits')
-    const rollMode = game.settings.get('core', 'rollMode')
+    const rollMode = game.settings.get('core', 'messageMode')
     // Accumulate all rolls for sending to the chat message
     const rolls = []
     // Attack roll
@@ -389,7 +389,7 @@ class XCCActorSheetBrawler extends XCCActorSheet {
 
     messageData.content = await foundry.applications.handlebars.renderTemplate('systems/dcc/templates/chat-card-attack-result.html', { message: messageData })
     // Output the results
-    ChatMessage.applyRollMode(messageData, rollMode)
+    ChatMessage.applyMode(messageData, rollMode)
     ChatMessage.create(messageData)
   }
 

--- a/module/xcc-actor-sheet-half-elf.js
+++ b/module/xcc-actor-sheet-half-elf.js
@@ -305,7 +305,7 @@ class XCCActorSheetHalfElf extends XCCActorSheet {
     const options = XCCActorSheet.fillRollOptions(event)
 
     const automateDamageFumblesCrits = game.settings.get('dcc', 'automateDamageFumblesCrits')
-    const rollMode = game.settings.get('core', 'rollMode')
+    const rollMode = game.settings.get('core', 'messageMode')
 
     // If weapon is not found, give up and show a warning
     if (!weapon) {
@@ -508,7 +508,7 @@ class XCCActorSheetHalfElf extends XCCActorSheet {
     messageData.content = await foundry.applications.handlebars.renderTemplate('systems/dcc/templates/chat-card-attack-result.html', { message: messageData })
 
     // Output the results
-    ChatMessage.applyRollMode(messageData, rollMode)
+    ChatMessage.applyMode(messageData, rollMode)
     ChatMessage.create(messageData)
   }
 

--- a/module/xcc-actor-sheet.js
+++ b/module/xcc-actor-sheet.js
@@ -60,7 +60,7 @@ export class XCCActorSheet extends DCCActorSheet {
   static async sponsorshipCreate (event, target) {
     const type = 'xcc-core-book.sponsorship'
     // Grab any data associated with this control.
-    const system = foundry.utils.duplicate(target.dataset)
+    const system = foundry.utils.deepClone(target.dataset)
     // Initialize a default name.
     const name = game.i18n.localize('XCC.Rewards.NewOffer')
     system.rewards = {
@@ -672,7 +672,7 @@ export class XCCActorSheet extends DCCActorSheet {
         const existingEndText = existingEndElement ? existingEndElement.innerHTML : null
 
         const newContent = await foundry.applications.handlebars.renderTemplate(globals.templatesPath + 'chat-card-table-result.html', {
-          results: newResults.map(r => foundry.utils.duplicate(r)),
+          results: newResults.map(r => foundry.utils.deepClone(r)),
           table: rollTable,
           emoteMessage: existingEmoteMessage,
           endText: existingEndText
@@ -778,7 +778,7 @@ export class XCCActorSheet extends DCCActorSheet {
       }
 
       const messageContent = await foundry.applications.handlebars.renderTemplate(globals.templatesPath + 'chat-card-table-result.html', {
-        results: tableResults.map(r => foundry.utils.duplicate(r)),
+        results: tableResults.map(r => foundry.utils.deepClone(r)),
         table: rollTable,
         actorName: this.actor.name,
         endText: endKey ? game.i18n.format(endKey, variables) : '',


### PR DESCRIPTION
## Summary
- Update module.json compatibility to V14
- Replace deprecated `duplicate()` with `deepClone()`
- Migrate `rollMode` setting to `messageMode`
- Replace `ChatMessage.applyRollMode` with `ChatMessage.applyMode`

## Test plan
- [x] Load XCC in FoundryVTT V14 with DCC system feature/v14
- [x] Open each custom class sheet (athlete, brawler, half-elf) and verify it renders
- [x] Make a roll from a custom sheet and verify roll mode is respected
- [x] Verify no deprecation warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)