### PR TITLE
fix: import Purple Sorcerer equipment with prices attached

### DIFF
--- a/module/xcc-parser.js
+++ b/module/xcc-parser.js
@@ -144,7 +144,10 @@ async function createActors (type, folderId, actorData) {
     }
   }
 
-  // Cache available items if importing players
+  // Cache available items if importing players, keyed by normalized name so
+  // Purple Sorcerer names like "Rope - 50'" match pack names like "Rope, 50’"
+  // (ported from the DCC system fix for foundryvtt-dcc/dcc#817). XCC pack
+  // entries intentionally overwrite DCC entries with the same name.
   // @TODO Implement a configuration mechanism for providing additional packs
   const itemMap = {}
   if (type === 'Player') {
@@ -153,7 +156,7 @@ async function createActors (type, folderId, actorData) {
       if (!pack) continue
 
       for (const entry of pack.index) {
-        itemMap[entry.name.toLowerCase()] = entry
+        itemMap[_normalizeItemName(entry.name)] = entry
       }
     }
     for (const packPath of CONFIG.XCC.actorImporterItemPacks) {
@@ -161,7 +164,7 @@ async function createActors (type, folderId, actorData) {
       if (!pack) continue
 
       for (const entry of pack.index) {
-        itemMap[entry.name.toLowerCase()] = entry
+        itemMap[_normalizeItemName(entry.name)] = entry
       }
     }
   }
@@ -263,7 +266,7 @@ async function createActors (type, folderId, actorData) {
             name = name.substring(0, qtyMatch)
           }
           // We have the final item name. Search for it in the cache
-          const mapEntry = itemMap[name.toLowerCase()]
+          const mapEntry = itemMap[_normalizeItemName(name)]
           if (mapEntry) {
             // Lookup the item document
             const compendiumItem = await fromUuid(mapEntry.uuid)
@@ -320,6 +323,24 @@ async function createActors (type, folderId, actorData) {
   }
 
   return actors
+}
+
+/**
+ * Normalize an item name for compendium matching: lower-case, straighten curly
+ * apostrophes, and collapse commas, hyphens, parentheses, and asterisks to
+ * spaces, so Purple Sorcerer names like "Rope - 50'" or "Flashlight - combat"
+ * match pack names like "Rope, 50’" and "Flashlight, combat".
+ * (Ported from the DCC system fix for foundryvtt-dcc/dcc#817.)
+ * @param {string} name - The item name to normalize
+ * @return {string} The normalized name
+ */
+function _normalizeItemName (name) {
+  return name
+    .toLowerCase()
+    .replace(/[’‘]/g, "'")
+    .replace(/[-,()*]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
 }
 
 // Returns the name of a random piece of equipment from the equipment compendium

--- a/module/xcc-pc-parser.js
+++ b/module/xcc-pc-parser.js
@@ -208,27 +208,15 @@ function _parseJSONPCs (pcObject) {
       notes = notes + game.i18n.localize('DCC.Equipment') + ':<br/>'
       if (pcObject.equipment) {
         notes = notes + '  ' + pcObject.equipment + '<br/>'
-        pc.items.push({
-          name: pcObject.equipment,
-          type: 'equipment',
-          img: EntityImages.imageForItem('equipment')
-        })
+        pc.items.push(_parseEquipmentItem(pcObject.equipment))
       }
       if (pcObject.equipment2) {
         notes = notes + '  ' + pcObject.equipment2 + '<br/>'
-        pc.items.push({
-          name: pcObject.equipment2,
-          type: 'equipment',
-          img: EntityImages.imageForItem('equipment')
-        })
+        pc.items.push(_parseEquipmentItem(pcObject.equipment2))
       }
       if (pcObject.equipment3) {
         notes = notes + '  ' + pcObject.equipment3 + '<br/>'
-        pc.items.push({
-          name: pcObject.equipment3,
-          type: 'equipment',
-          img: EntityImages.imageForItem('equipment')
-        })
+        pc.items.push(_parseEquipmentItem(pcObject.equipment3))
       }
       if (pcObject.tradeGood) {
         notes = notes + '  ' + pcObject.tradeGood + ' (' + game.i18n.localize('DCC.TradeGoods') + ')<br/>'
@@ -248,11 +236,7 @@ function _parseJSONPCs (pcObject) {
           pcObject.tradeGood = pcObject.tradeGood.substring(9)
           addPackE(pc)
         }
-        pc.items.push({
-          name: pcObject.tradeGood.capitalize(),
-          type: 'equipment',
-          img: EntityImages.imageForItem('equipment')
-        })
+        pc.items.push(_parseEquipmentItem(pcObject.tradeGood.capitalize()))
         notes = notes + '<br/>'
       }
     }
@@ -601,6 +585,29 @@ function _parseWeapon (weaponString) {
   }
 
   return null
+}
+
+/**
+ * Create an equipment item from a Purple Sorcerer equipment string.
+ * Purple Sorcerer appends prices to equipment names (e.g. "Candle (1 cp)");
+ * strip the trailing price parenthetical from the name and store it in the
+ * item's currency value so the price survives import.
+ * (Ported from the DCC system fix for foundryvtt-dcc/dcc#817.)
+ * @param {string} equipmentString - The raw equipment or trade good text
+ * @return {Object} Equipment item data
+ */
+function _parseEquipmentItem (equipmentString) {
+  const item = {
+    name: equipmentString,
+    type: 'equipment',
+    img: EntityImages.imageForItem('equipment')
+  }
+  const priceMatch = equipmentString.match(/^(.*?)\s*\((\d+)\s*(pp|ep|gp|sp|cp)\)\s*$/i)
+  if (priceMatch) {
+    item.name = priceMatch[1]
+    item.system = { value: { [priceMatch[3].toLowerCase()]: priceMatch[2] } }
+  }
+  return item
 }
 
 function _parseArmor (armorString) {


### PR DESCRIPTION
## Summary

Port of the DCC system importer fix (foundryvtt-dcc/dcc#817 / foundryvtt-dcc/dcc#830) to XCC's forked parser. Purple Sorcerer appends prices to equipment names (`Backpack (2 gp)`, `Rope - 50' (25 cp)`), which broke this importer's exact lowercased-name compendium lookup the same way it broke the system's.

## Changes

- **`module/xcc-pc-parser.js`** — equipment and trade-good lines go through a new `_parseEquipmentItem` helper that strips a trailing `(N pp|ep|gp|sp|cp)` price parenthetical from the item name and stores it in `system.value`, so the price survives import even when there's no compendium match. The raw text (price included) still goes to the notes. Coin lines like `50 gp` and quantity suffixes like `Arrows (20)` are unaffected (the price regex requires a parenthesized amount + currency).
- **`module/xcc-parser.js`** — the compendium cache and lookup now use a normalized name (lower-case, curly→straight apostrophes, commas/hyphens/parens/asterisks collapsed to spaces), so `Rope - 50'` matches the pack's `Rope, 50’` and `Flashlight - combat` matches `Flashlight, combat`. XCC pack entries still overwrite same-name DCC entries, and the `actorImporterNameMap` lookup keys are untouched.

Unlike the system fix, **no type gate was added**: XCC's remap is intentionally cross-type (its name map turns equipment lines into armor/weapons like `chain mail & extra weapon`), and containers already matched here when names lined up.

## Testing

- `node --check` + `standard` clean on both files.
- Helper logic (normalization pairs from the real name map/packs, price stripping, `50 gp`/`Arrows (20)` pass-through) verified in a standalone script.
- Not boot-tested in a live world with xcc-core-book active — the equivalent DCC-system pipeline is covered end-to-end by the new `actor-import.spec.js` in foundryvtt-dcc/dcc#830.

🤖 Generated with [Claude Code](https://claude.com/claude-code)