### PR TITLE
Mojo launcher in the DCC Tools sidebar tab

### DIFF
--- a/module.json
+++ b/module.json
@@ -22,8 +22,8 @@
         "id": "dcc",
         "type": "system",
         "compatibility": {
-          "minimum": "0.70.0",
-          "verified": "0.70.0"
+          "minimum": "0.70.31",
+          "verified": "0.70.34"
         }
       }
     ]

--- a/module/xcc.js
+++ b/module/xcc.js
@@ -113,6 +113,25 @@ Hooks.on('dcc.definePlayerSchema', (schema) => {
     totalWealth: new NumberField({ initial: 0, integer: true })
   })
 })
+
+/**
+ * DCC Tools sidebar tab (DCC issue #833): in XCrawl the fleeting-luck
+ * mechanic is Mojo — our lang overrides already relabel the whole
+ * DCC.FleetingLuck vocabulary — and it is always on (see the `enabled`
+ * override in the `dcc.ready` block below). The core tool is gated on the
+ * `dcc.enableFleetingLuck` setting, so re-seed it unconditionally with a
+ * Mojo-flavored icon. Registered at import time so the sidebar's first
+ * render (during `Game#initializeUI`, before `ready`) already includes it;
+ * on DCC versions without the sidebar tab the hook simply never fires.
+ */
+Hooks.on('dcc.getSidebarTools', (tools) => {
+  tools.fleetingLuck = {
+    label: 'DCC.FleetingLuck',
+    icon: 'fas fa-hand-sparkles',
+    onClick: () => game.dcc.FleetingLuck.show()
+  }
+})
+
 const { loadTemplates } = foundry.applications.handlebars
 
 /* -------------------------------------------- */
@@ -478,9 +497,11 @@ Hooks.once('dcc.ready', async function () {
     if (caption) caption.textContent = game.i18n.localize('DCC.FancyPause')
   })
 
-  // Re-Initialize Fleeting Luck UI
+  // Re-Initialize Fleeting Luck UI (the Mojo tracker). The scene-controls
+  // re-render that used to surface the Fleeting Luck button is gone — the
+  // launcher now lives in the DCC Tools sidebar tab via the
+  // `dcc.getSidebarTools` listener registered at import time.
   game.dcc.FleetingLuck.init()
-  foundry.ui.controls.render()
 
   // Enrich class arrays
   await enrichClass('XCC.Athlete')


### PR DESCRIPTION
DCC moved the Fleeting Luck / Spell Duel launchers off the left-hand scene controls into the right-hand **DCC Tools** sidebar tab (foundryvtt-dcc/dcc#833, shipped in DCC 0.70.31), and the `foundry.ui.controls.render()` re-render in our `dcc.ready` block no longer surfaces anything.

## Summary
- Register a `dcc.getSidebarTools` listener at import time (so the sidebar's first render includes it) that re-seeds the fleeting-luck tool **unconditionally**: in XCrawl the mechanic is Mojo and always on — the core tool is gated on `dcc.enableFleetingLuck`, which XCC worlds don't use
- The tool renders as **Mojo** via our existing `DCC.FleetingLuck` lang overrides (dialog vocabulary stays consistent), with a Mojo-flavored hand-sparkles icon
- Drop the now-inert scene-controls re-render; keep the `FleetingLuck.init()` re-init
- `module.json`: DCC minimum bumped to 0.70.31 (hook introduction), verified 0.70.34

## Test plan
- [x] `standard` lint clean
- [x] Listener pattern verified against a live DCC 0.70.34 world: with `enableFleetingLuck` **off**, the tool still renders in the DCC Tools tab with the hand-sparkles icon (label falls back to Fleeting Luck there because XCC's lang overrides aren't loaded in a DCC-only world; in an XCC world it reads Mojo)
- [ ] Boot-test in an XCC world before release

🤖 Generated with [Claude Code](https://claude.com/claude-code)